### PR TITLE
fix: 非同期関数にはasyncをつけよう

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -10,7 +10,7 @@ const app = new App({
  *
  * @param {string} message 送信したい内容
  */
-function logging(message) {
+async function logging(message) {
   // チャンネルに質問内容を送信
   const channelId = "C029QSVP30C";
 


### PR DESCRIPTION
詳しい話はさておき、`await` を使う場合には function の前に `async` を書くというJavaScriptのルールがあるのを忘れていた

## 対応
- 今回は node src/app.js を動かせばエラーが出て気づけたので、pushする前に動作をサボらず確認しよう！